### PR TITLE
Initial new raider-specific config

### DIFF
--- a/lib/longboat/config.rb
+++ b/lib/longboat/config.rb
@@ -33,7 +33,9 @@ module Longboat
     def self.for_raider(&block)
       parser = Optimist::Parser.new(&block)
       parser.ignore_invalid_options = true
-      parser.parse
+      opts = parser.parse
+      opts.delete(:help)
+      opts
     end
   end
 end

--- a/lib/longboat/config.rb
+++ b/lib/longboat/config.rb
@@ -5,15 +5,15 @@ module Longboat
     def self.parse!
       parser = Optimist::Parser.new do
         # Collection interval
-        opt :raid_every,     "Collection interval",               type: Integer, default: 60
+        opt :raid_every,     "Collection interval",               type: Integer,    default: 60
 
         # Job data
-        opt :raiders_path,   "Paths to search for raiders",       type: String,  default: "./lib/raiders",     multi: true
-        opt :metric_prefix,  "Prefix for metric names",           type: String,  default: "longboat_"
+        opt :raiders_path,   "Paths to search for raiders",       type: String,     default: "./lib/raiders",     multi: true
+        opt :metric_prefix,  "Prefix for metric names",           type: String,     default: "longboat_"
 
         # Sinatra server
-        opt :server_bind,    "Server listening address",          type: String,  default: "127.0.0.1:8564"
-        opt :server_path,    "Path to metrics",                   type: String,  default: "/metrics"
+        opt :server_bind,    "Server listening address",          type: String,     default: "127.0.0.1:8564"
+        opt :server_path,    "Path to metrics",                   type: String,     default: "/metrics"
 
         # Testing
         opt :test,           "Output metrics to stdout and quit", type: TrueClass,  default: false

--- a/lib/longboat/config.rb
+++ b/lib/longboat/config.rb
@@ -3,7 +3,7 @@ require 'optimist'
 module Longboat
   module Config
     def self.parse!
-      Optimist::options do
+      parser = Optimist::Parser.new do
         # Collection interval
         opt :raid_every,     "Collection interval",               type: Integer, default: 60
 
@@ -18,6 +18,22 @@ module Longboat
         # Testing
         opt :test,           "Output metrics to stdout and quit", type: TrueClass,  default: false
       end
+      parser.ignore_invalid_options = true
+
+      begin
+        parser.parse
+      rescue Optimist::HelpNeeded
+        parser.educate
+        exit
+      rescue Optimist::VersionNeeded
+        exit
+      end
+    end
+
+    def self.for_raider(&block)
+      parser = Optimist::Parser.new(&block)
+      parser.ignore_invalid_options = true
+      parser.parse
     end
   end
 end

--- a/lib/longboat/raiders.rb
+++ b/lib/longboat/raiders.rb
@@ -15,9 +15,7 @@ module Longboat
           cname = reqname.split('_').map(&:capitalize).join
 
           require "#{dir}/#{reqname}"
-          raider = Kernel.const_get(cname).new(@collector, raider_config)
-          raider.configure! if raider.respond_to?(:configure!)
-          @raiders[reqname] = raider
+          @raiders[reqname] = Kernel.const_get(cname).new(@collector, raider_config)
         end
       end
     end

--- a/lib/longboat/raiders.rb
+++ b/lib/longboat/raiders.rb
@@ -15,7 +15,9 @@ module Longboat
           cname = reqname.split('_').map(&:capitalize).join
 
           require "#{dir}/#{reqname}"
-          @raiders[reqname] = Kernel.const_get(cname).new(@collector, raider_config)
+          raider = Kernel.const_get(cname).new(@collector, raider_config)
+          raider.configure! if raider.respond_to?(:configure!)
+          @raiders[reqname] = raider
         end
       end
     end

--- a/longboat
+++ b/longboat
@@ -11,8 +11,9 @@ collector = Longboat::Collector.new(config)
 raiders = Longboat::Raiders.new(collector, config)
 
 unless ARGV.empty?
-  puts "Extraneous arguments:"
-  p ARGV
+  puts "Extraneous or unrecognised arguments:"
+  puts "    " + ARGV.join(" ")
+  puts "Try --help, or refer to raider documentation."
   exit 1
 end
 

--- a/longboat
+++ b/longboat
@@ -10,6 +10,12 @@ config = Longboat::Config.parse!
 collector = Longboat::Collector.new(config)
 raiders = Longboat::Raiders.new(collector, config)
 
+unless ARGV.empty?
+  puts "Extraneous arguments:"
+  p ARGV
+  exit 1
+end
+
 if config.test
   # We're in test mode, output metrics to stdout once and quit
   raiders.raid!


### PR DESCRIPTION
Whatchu think? Raiders can now have config which shlurps up options from the command line

```
class Test
  def initialize
    @config.merge!(Longboat::Config.for_raider do
      opt :a_value, "A nice integer value", type: Integer, default: 4
    end)
  end
...
end
```